### PR TITLE
about.html: Fix links, use HTTPS urls

### DIFF
--- a/speed_python/templates/about.html
+++ b/speed_python/templates/about.html
@@ -7,12 +7,12 @@
 <h3>About this site</h3>
 <p>Welcome to the speed.python.org project - this project is aimed at
 constructing a shared benchmark system based on the excellent
-<a href="http://speed.pypy.org/" target="_blank">speed.pypy.org</a>
+<a href="https://speed.pypy.org/" target="_blank">speed.pypy.org</a>
 project.</p>
 <p>This project will setup a common, shared instance of the benchmarking
 suite and visualization tools put together by the
-<a href="http://pypy.org/" target="_blank">PyPy team</a>, based on work
-from the <a href="http://code.google.com/p/unladen-swallow/" target="_blank">
+<a href="https://pypy.org/" target="_blank">PyPy team</a>, based on work
+from the <a href="https://code.google.com/p/unladen-swallow/" target="_blank">
 Unladen Swallow project</a>.
 <p>Coming out of the PyCon 2011 VM and language summits, it was commonly
 agreed that PyPy, CPython, IronPython and Jython should strive to move
@@ -30,12 +30,12 @@ the community as a whole.
 </p>
 <p>You can see the announcement, and more details at the announcement of the
 machine acquisition on
-<a href="http://jessenoller.com/2011/06/29/announcing-the-new-speed-python-org-machine/" target="_blank">
+<a href="http://jessenoller.com/blog/2011/06/29/announcing-the-new-speed-python-org-machine" target="_blank">
 Jesse Noller's blog.</a></p>
 <p>For now, only CPython is being benchmarked, but we hope to expand in the future.</p>
 <h4>The Machine</h4>
 <p>Nicknamed "the beast" - the speed.python.org machine was generously donated to the
-Python Software foundation by the <a href="http://hp.com/go/linux" target="_blank">
+Python Software foundation by the <a href="https://hp.com/go/linux" target="_blank">
 HP Open Source Program office</a>.
 <p>The hardware specs are:
 <ul>
@@ -58,7 +58,7 @@ HP's generous donation can not be spoken of highly enough.
 
 <h4>The Hosting</h4>
 <p>The racking, stacking and hardware administration and all bandwidth has been
-generously donated by the <a href="http://osuosl.org/" target="_blank">
+generously donated by the <a href="https://osuosl.org/" target="_blank">
 The Oregon State University Open Source Lab</a> (OSUOSL)
 who have been amazing open source supporters, and supporters of the Python
 Software foundation.</p>
@@ -68,12 +68,12 @@ Software foundation.</p>
 <h4>Resources</h4>
 <ul>
     <li>
-        <a href="http://mail.python.org/mailman/listinfo/speed" target="_blank">The mailing list</a>
+        <a href="https://mail.python.org/mailman/listinfo/speed" target="_blank">The mailing list</a>
         is here - if you want to volunteer to help out with the project, this
         is the place to start.
     </li>
     <li>
-        <a href="http://mail.python.org/pipermail/speed/" target="_blank">The list archives</a>
+        <a href="https://mail.python.org/pipermail/speed/" target="_blank">The list archives</a>
     </li>
 </ul>
 
@@ -84,11 +84,11 @@ Software foundation.</p>
 <p>Main website: <a href="https://python.org/">python.org</a></p>
 <h3>About Codespeed</h3>
 Codespeed is a web application to monitor and analyze the performance of your code.
-<p>Original Code: <a href="http://github.com/tobami/codespeed">github.com/tobami/codespeed</a></p>
-<p>Code for this site: <a href="http://github.com/zware/codespeed">github.com/zware/codespeed</a></p>
-<p>Wiki: <a href="http://wiki.github.com/tobami/codespeed/">wiki.github.com/tobami/codespeed/</a></p>
+<p>Original Code: <a href="https://github.com/tobami/codespeed">github.com/tobami/codespeed</a></p>
+<p>Code for this site: <a href="https://github.com/zware/codespeed">github.com/zware/codespeed</a></p>
+<p>Wiki: <a href="https://github.com/tobami/codespeed/wiki">github.com/tobami/codespeed/wiki</a></p>
 <h3>Contact</h3>
 <p>For problems or suggestions about this website write to
-    <a href="http://mail.python.org/mailman/listinfo/speed">the Python Speed mailing list</a></p>
+    <a href="https://mail.python.org/mailman/listinfo/speed">the Python Speed mailing list</a></p>
 </div>
 {% endblock %}

--- a/speed_python/templates/about.html
+++ b/speed_python/templates/about.html
@@ -68,12 +68,12 @@ Software foundation.</p>
 <h4>Resources</h4>
 <ul>
     <li>
-        <a href="https://mail.python.org/mailman/listinfo/speed" target="_blank">The mailing list</a>
+        <a href="https://mail.python.org/mailman3/lists/speed.python.org/" target="_blank">The mailing list</a>
         is here - if you want to volunteer to help out with the project, this
         is the place to start.
     </li>
     <li>
-        <a href="https://mail.python.org/pipermail/speed/" target="_blank">The list archives</a>
+        <a href="https://mail.python.org/archives/list/speed@python.org/" target="_blank">The list archives</a>
     </li>
 </ul>
 
@@ -89,6 +89,6 @@ Codespeed is a web application to monitor and analyze the performance of your co
 <p>Wiki: <a href="https://github.com/tobami/codespeed/wiki">github.com/tobami/codespeed/wiki</a></p>
 <h3>Contact</h3>
 <p>For problems or suggestions about this website write to
-    <a href="https://mail.python.org/mailman/listinfo/speed">the Python Speed mailing list</a></p>
+    <a href="https://mail.python.org/mailman3/lists/speed.python.org/">the Python Speed mailing list</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
- Made all remaining links https:// except for jessenoller.com, which doesn't have a valid certificate
- The jessenoller.com post has been moved to a slightly different URL, updated link
- wiki.github.com isn't even a valid host; fixed wiki link